### PR TITLE
Adding support for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ conditional branches, or the target binary is cumbersome to launch.
 ```console
 ./gecho
 ```
-Will output `{"arguments":["./gecho"]}`.
+Will output `{"arguments":["./gecho"],"envvars":["NAME=VALUE"]}`.  The `envvars`
+array will contain an element for every environment variable that was passed to
+the process (i.e. exported on Unix-like platforms).  The elements are reported
+as they are received from the `os.Environ()` function: variable name, equal
+sign, and variable value as a single string.
 
 ```console
 ./gecho -la directory/
 ```
-Will output `{"arguments":["./gecho","-la","directory/"]}`.
+Will output `{"arguments":["./gecho","-la","directory/"],"envvars":[NAME=VALUE]}`.
 
 ## Building
 ```console

--- a/gecho.go
+++ b/gecho.go
@@ -10,15 +10,15 @@ import (
 // ArgsEnvVarReport is a structure that contains all of command line arguments
 // and environment variables passed to this process, which can be encoded into
 // a JSON representation.
-type ArgsEnvVarReport struct {
+type argsEnvVarReport struct {
   Arguments []string `json:"arguments"`
-  //EnvVars map[string]string `json:"environmentVariables"`
+  EnvVars []string `json:"envvars"`
 }
 
 // Report builds a JSON encoded report from the provided arguments and
 // environment variables.
-func Report(args []string) string {
-  report := ArgsEnvVarReport{ Arguments: args}
+func Report(args, envs []string) string {
+  report := argsEnvVarReport{ Arguments: args, EnvVars: envs}
 
   buffer := &bytes.Buffer{}
   if err := json.NewEncoder(buffer).Encode(report); err != nil {
@@ -29,7 +29,7 @@ func Report(args []string) string {
 }
 
 func main() {
-  fmt.Println(Report(os.Args[0:]))
+  fmt.Println(Report(os.Args[0:], os.Environ()))
 
   os.Exit(0)
 }

--- a/gecho_test.go
+++ b/gecho_test.go
@@ -9,16 +9,43 @@ import (
 func TestReport(t *testing.T) {
   testcases := []struct{
     args []string
+    envs []string
     expected string
   } {
-    {args: []string{"first"}, expected: "{\"arguments\":[\"first\"]}\n"},
-    {args: []string{"one", "two", "three"}, expected: "{\"arguments\":[\"one\",\"two\",\"three\"]}\n"},
-    {args: []string{"gecho", "-c", "12", "--verbose"}, expected: "{\"arguments\":[\"gecho\",\"-c\",\"12\",\"--verbose\"]}\n"},
-    {args: []string{"binary", "", "\\", "\""}, expected: "{\"arguments\":[\"binary\",\"\",\"\\\\\",\"\\\"\"]}\n"},
+    {
+      args: []string{"first"},
+      envs: []string{},
+      expected: "{\"arguments\":[\"first\"],\"envvars\":[]}\n",
+    },
+    {
+      args: []string{"one", "two", "three"},
+      envs: []string{},
+      expected: "{\"arguments\":[\"one\",\"two\",\"three\"],\"envvars\":[]}\n",
+    },
+    {
+      args: []string{"gecho", "-c", "12", "--verbose"},
+      envs: []string{},
+      expected: "{\"arguments\":[\"gecho\",\"-c\",\"12\",\"--verbose\"],\"envvars\":[]}\n",
+    },
+    {
+      args: []string{"binary", "", "\\", "\""},
+      envs: []string{},
+      expected: "{\"arguments\":[\"binary\",\"\",\"\\\\\",\"\\\"\"],\"envvars\":[]}\n",
+    },
+    {
+      args: []string{"binary", "", "\\", "\""},
+      envs: []string{"DEBUG=1"},
+      expected: "{\"arguments\":[\"binary\",\"\",\"\\\\\",\"\\\"\"],\"envvars\":[\"DEBUG=1\"]}\n",
+    },
+    {
+      args: []string{"program", "-a", "file.txt"},
+      envs: []string{"HOME=/home/user", "SHELL=/usr/bin/bash", "QUOTE=\""},
+      expected: "{\"arguments\":[\"program\",\"-a\",\"file.txt\"],\"envvars\":[\"HOME=/home/user\",\"SHELL=/usr/bin/bash\",\"QUOTE=\\\"\"]}\n",
+    },
   }
 
   for _, testcase := range testcases {
-    result := Report(testcase.args)
+    result := Report(testcase.args, testcase.envs)
 
     assert.Equal(t, result, testcase.expected)
   }


### PR DESCRIPTION
This PR adds support for displaying the environment variables received by the process.  They are reported as single elements that are comprised of the variable's name and value separated by an equal sign (=).  This is the format that the `os.Environ()` function uses.